### PR TITLE
Fix missing google/apiclient dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
             "YouTubePartner.php"
         ]
 	
-}
+},
+    "require": {
+        "google/apiclient": "^2.0"
+    }
 }


### PR DESCRIPTION
It's unlikely someone would specifically require this library alone, but at the least this makes investigating this library much easier when your IDE can reference all of the related classes.